### PR TITLE
Update README.md with logpresso's solution

### DIFF
--- a/scanning/README.md
+++ b/scanning/README.md
@@ -27,5 +27,4 @@ Checks if the application or system is using Log4j2.
 | sp4ir     | Powershell script to detect Log4Shell| https://github.com/sp4ir/incidentresponse/blob/35a2faae8512884bcd753f0de3fa1adc6ec326ed/Get-Log4shellVuln.ps1 |
 | NCCgroup  | Version hashes (MD5, SHA1 and SHA256) for log4j2 versions| https://github.com/nccgroup/Cyber-Defence/tree/master/Intelligence/CVE-2021-44228 |
 | 1lann  | Scans a file or folder recursively for jar files that may be vulnerable | https://github.com/1lann/log4shelldetect |
-| Syft | Open source SBOM scanner, can detect all dependencies including log4j | https://github.com/anchore/syft/ |
-
+| logpresso | Scans for java files that are vulnerable and may rename it for mitigation | https://github.com/logpresso/CVE-2021-44228-Scanner |


### PR DESCRIPTION
log4j2-scan is a single binary command-line tool for CVE-2021-44228 vulnerability scanning and mitigation patch. It also supports nested JAR file scanning and patch.