### PR TITLE
Remove ESET entry

### DIFF
--- a/software/README.md
+++ b/software/README.md
@@ -453,7 +453,6 @@ NCSC-NL will use the following status:
 | Elastic         | Machine Learning | | Not Vuln |   | [source](https://discuss.elastic.co/t/apache-log4j2-remote-code-execution-rce-vulnerability-cve-2021-44228-esa-2021-31/291476) |
 | Elastic         | Swiftype | | Investigation |   | [source](https://discuss.elastic.co/t/apache-log4j2-remote-code-execution-rce-vulnerability-cve-2021-44228-esa-2021-31/291476) |
 | ELO             | Digital Office || Not Vuln || [source](http://www.elo.com)|
-| ESET            | All products | Unknown | Not vuln | |[source](https://forum.eset.com/topic/30691-log4j-vulnerability/) |
 | Esri | ArcGIS Enterprise and related products | < 10.8.0 | Vulnerable |  | [source](https://www.esri.com/arcgis-blog/products/arcgis-enterprise/administration/arcgis-software-and-cve-2021-44228-aka-log4shell-aka-logjam/) |
 | EVL Labs | JGAAP | <8.0.2 | Fix | | [source](https://github.com/evllabs/JGAAP/releases/tag/v8.0.2) |
 | eXtreme Hosting | All products | Unknown | Not vuln | |[source](https://extremehosting.nl/log4shell-log4j/) |


### PR DESCRIPTION
I believe the ESET entry is false - scrolling up from the previously provided source, you see this comment that ESET does not use log4j and are not impacted. 
 https://forum.eset.com/topic/30691-log4j-vulnerability/?do=findComment&comment=143745