### PR TITLE
esri provided scripts which remove JndiLookup class, updated status to workaround

### DIFF
--- a/software/README.md
+++ b/software/README.md
@@ -761,7 +761,7 @@ The `Version` relates to the `Status` column. If `Status` is Vulnerable, Version
 | Elastic         | Swiftype | | Investigation |   | [source](https://discuss.elastic.co/t/apache-log4j2-remote-code-execution-rce-vulnerability-cve-2021-44228-esa-2021-31/291476) |
 | ELO | Digital Office || Not Vuln || [source](http://www.elo.com)|
 | ESET | All products | Unknown | Not vuln | |[source](https://support.eset.com/en/alert8188-information-regarding-the-log4j2-vulnerability) |
-| Esri | ArcGIS Enterprise and related products | < 10.8.0 | Vulnerable |  | [source](https://www.esri.com/arcgis-blog/products/arcgis-enterprise/administration/arcgis-software-and-cve-2021-44228-aka-log4shell-aka-logjam/) |
+| Esri | ArcGIS Enterprise and related products | < 10.8.0 | Workaround | See source for workaround  | [source](https://www.esri.com/arcgis-blog/products/arcgis-enterprise/administration/arcgis-software-and-cve-2021-44228-aka-log4shell-aka-logjam/) |
 | estos            | All products | Unknown | Not vuln | |[source](https://support.estos.de/de/sicherheitshinweise/estos-von-kritischer-schwachstelle-in-log4j-cve-2021-44228-nicht-betroffen) |
 | EVL Labs | JGAAP | <8.0.2 | Fix | | [source](https://github.com/evllabs/JGAAP/releases/tag/v8.0.2) |
 | Exivity | Exivity On-Premise | All version | Not Vuln | | [source](https://docs.exivity.com/getting-started/releases/announcements#announcement-regarding-cve-2021-44228) |


### PR DESCRIPTION
esri provided scripts which remove JndiLookup class for vulnerable versions




Thank you for your contribution! Some pointers to get it merged quickly:

For contributions in `software/`:

  - Status: please select a value from the status table at the top
  - Version: Status Vulnerable / Workaround? -> List vulnerable versions.
             Status Fix?                     -> List fixed versions.
  - Links: make sure you link to a public statement by the developer.
    Alternatively, include and link a file in the `software/vendor-statements/`
    directory
  - Please mind the sorting
  - Please put vendor/product name in PR title (instead of "Update README.md")
