### PR TITLE
network egress controls to 'contain' the code execution

### DIFF
--- a/mitigation/README.md
+++ b/mitigation/README.md
@@ -35,6 +35,7 @@ Error looking up JNDI resource
 |:----------------|:----------------|:---------------:|
 | Akamai       | Cloud | https://www.akamai.com/blog/news/CVE-2021-44228-Zero-Day-Vulnerability |
 | AWS          | Cloud | https://aws.amazon.com/blogs/security/using-aws-security-services-to-protect-against-detect-and-respond-to-the-log4j-vulnerability/ |
+| Chaser Systems | discrimiNAT Firewall | [Log4Shell RCE outbound traffic – tracing and blocking at network egress](https://chasersystems.com/discrimiNAT/blog/log4shell-and-its-traces-in-a-network-egress-filter/) |
 | Cloudflare   | Cloud | https://blog.cloudflare.com/cve-2021-44228-log4j-rce-0-day-mitigation/ |
 | Citrix     | Citrix WAF | https://www.citrix.com/blogs/2021/12/13/guidance-for-reducing-apache-log4j-security-vulnerability-risk-with-citrix-waf/ |
 | Elastic      | Elastic | https://www.elastic.co/blog/detecting-log4j2-with-elastic-security |


### PR DESCRIPTION
As per NCC Group's recommendation: "Limit network egress from hosts where vulnerable software exists when possible." , and, 
Substack's Risky Business recommendation: "network-based egress controls that restrict outbound connections to attacker-controlled infrastructure to the list — they're critically important right now."