### PR TITLE
Textual changes to the software list page.

### DIFF
--- a/software/README.md
+++ b/software/README.md
@@ -10,7 +10,7 @@ NCSC-NL has published a HIGH/HIGH advisory for the Log4j vulnerability. Normally
 #### Daily CSV/JSON releases
 Daily releases of this software list are listed, including CSV and JSON files, in the [releases](https://github.com/NCSC-NL/log4shell/releases) overview. Please check the [software list parser](https://github.com/NCSC-NL/log4shell/tree/main/tools/log4shell_softwarelist) tool to generate a CSV or JSON on your own.
 
-> **Disclaimer:** _We aim to provide as the information as accurately as possible with the resources available to us. However, we do not have the capacity to monitor all software for updates/fixes. If you detect any mistakes, please create a Pull Request.
+> **Disclaimer:** _We aim to provide as the information as accurately as possible with the resources available to us. However, we do not have the capacity to monitor all software for updates/fixes. You are advised to review the links provided for available updates. If you find updates or mistakes, please contribute by creating a Pull Request. [Learn how](https://docs.github.com/en/repositories/working-with-files/managing-files/editing-files#editing-files-in-another-users-repository).
 
 ## Software overview
 NCSC-NL will use the following status labels:

--- a/software/README.md
+++ b/software/README.md
@@ -1,10 +1,19 @@
-> **Important: github only shows the first 512kb of this file in the preview. If you don't see the entire software list, please click [here](README.md) to load the entire list.**
+> **Important: GitHub only shows the first 512kb of this file in the preview. If you don't see the entire software list, please click [here](README.md) to load the entire list.**
 
 # Log4j overview related software
 
-This page contains an overview of any related software regarding the Log4j vulnerability. On this page NCSC-NL will maintain a list of all known vulnerable and not vulnerable software. Futhermore any reference to the software will contain specific information regarding which version contains the security fixes, and which software still requires mitigation. Please note that this vulnerability may also occur in custom software developed within your organisation. These occurrences are not registered in this overview.
+This page contains an overview of any related software regarding the Log4j vulnerability. On this page NCSC-NL and partners will maintain a list of all known vulnerable and not vulnerable software. Furthermore, references to software will contain specific information regarding which version contains the security fixes and which software still requires fixes. Please note that this vulnerability may also occur in custom software developed within your organisation. These occurrences are not registered in this overview.
 
-NCSC-NL will use the following status:
+#### NCSC Advisories
+NCSC-NL has published a HIGH/HIGH advisory for the Log4j vulnerability. Normally we would update the HIGH/HIGH advisory for vulnerable software packages, however due to the extensive amounts of expected updates we have created a list of known vulnerable software in the software directory.
+
+#### Daily CSV/JSON releases
+Daily releases of this software list are listed, including CSV and JSON files, in the [releases](https://github.com/NCSC-NL/log4shell/releases) overview. Please check the [software list parser](https://github.com/NCSC-NL/log4shell/tree/main/tools/log4shell_softwarelist) tool to generate a CSV or JSON on your own.
+
+> **Disclaimer:** _We aim to provide as the information as accurately as possible with the resources available to us. However, we do not have the capacity to monitor all software for updates/fixes. If you detect any mistakes, please create a Pull Request.
+
+## Software overview
+NCSC-NL will use the following status labels:
 
 | Status CVE-2021-xxx | Description                                                      |
 |:--------------------|:-----------------------------------------------------------------|
@@ -14,14 +23,7 @@ NCSC-NL will use the following status:
 | Not vuln            | Software is **NOT** vulnerable for CVE-2021-xxx.                 |
 | Investigation       | Software is under investigation whether it is vulnerable or not. |
 
-The `Version` relates to the `Status` column. If `Status` is _Vulnerable_, `Version` indicates vulnerable version(s). If `Status` is _Fix_, `Version` indicates the version(s) in which the fix was introduced.
-
-**NCSC-NL has published a HIGH/HIGH advisory for the Log4j vulnerability. Normally we would update the HIGH/HIGH advisory for vulnerable software packages, however due to the extensive amounts of expected updates we have created a list of known vulnerable software in the software directory.**
-
-
-_Note: daily releases of this software list are listed, including CSV and JSON files, in the [releases](https://github.com/NCSC-NL/log4shell/releases) overview. Please check the [software list parser](https://github.com/NCSC-NL/log4shell/tree/main/tools/log4shell_softwarelist) tool to generate a CSV or JSON on your own._
-
-## Software overview
+The `Version` relates to the `Status` column. If `Status` field is set to 'Vulnerable', the `Version` field indicates vulnerable version(s) if these version numbers are known to us. If `Status` is set to 'Fix', the `Version` field indicates the version(s) in which the fix was introduced. Some products do not have clear version numbers, in which case the `Version` field is empty. We advise readers to follow the provided source links for more detailed information.
 
 [0-9](#0-9) [A](#a) [B](#b) [C](#c) [D](#d) [E](#e) [F](#f) [G](#g) [H](#h) [I](#i) [J](#j) [K](#k) [L](#l) [M](#m) [N](#n) [O](#o) [P](#p) [Q](#q) [R](#r) [S](#s) [T](#t) [U](#u) [V](#v) [W](#w) [X](#x) [Y](#y) [Z](#z)
 


### PR DESCRIPTION
# Description

- Textual changes and headings.
- Added disclaimer
- Added clarity about the fact that the `Version` field is sometimes empty when `Fix` is present.
- Fixed some typo's.