### PR TITLE
Add log4shell-finder to scanning tools

### DIFF
--- a/scanning/README.md
+++ b/scanning/README.md
@@ -20,6 +20,7 @@ Checks if the application is vulnerable to CVE-2021-44228.
 | Grype   | Open source vulnerability scanner (docker), picks up nested JARs containing log4j | https://github.com/anchore/grype |
 | Huntress  | Online Log4Shell Vulnerability Tester| https://log4shell.huntress.com/ |
 | logpresso | Scans for java files that are vulnerable and may rename it for mitigation | https://github.com/logpresso/CVE-2021-44228-Scanner |
+| log4shell-finder | Fast file system scanner for log4j 1.x and 2.x vulnerabile instaces | https://github.com/HynekPetrak/log4shell-finder |
 | Logout4shell | Exploits the log4shell vulnerability in order to vaccinate the vulnerable target | https://github.com/Cybereason/Logout4Shell |
 | Northwave Security | Northwave Log4j CVE-2021-44228 checker (python) | https://github.com/NorthwaveSecurity/log4jcheck |
 | Northwave Security | Northwave Log4j CVE-2021-44228 checker Powershell version | https://github.com/crypt0jan/log4j-powershell-checker |


### PR DESCRIPTION
Hi,
I wrote (yet) another file system scanner, which seems to be faster then the other available, attempting to be precise in version detection and exhaustive in identifying vulnerable instances.
- Identifies exact log4j version in the 2.x as well as 1.x range
- Detecting CVE-2021-44832, CVE-2021-44228, CVE-2021-45046, CVE-2021-45105, CVE-2021-4104
- Optionally fixing vulnerability by renaming JndiLookup class

Link: https://github.com/HynekPetrak/log4shell-finder

This pull requests adds it to the list of Scanning software.
